### PR TITLE
Support asm-dom@0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "7"
   - "8"
   - "9"
+  - "10"
 script:
   - npm run check:src
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "6"
   - "7"
   - "8"
+  - "9"
 script:
   - npm run check:src
   - npm run build

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -17,6 +17,7 @@
 		- [Children](#children)
 	- [NULL children](#null-children)
 - [Comments](#comments)
+- [Fragments](#fragments)
 
 
 ## Introduction
@@ -128,17 +129,19 @@ Attributes corresponds to [`asmdom::Attrs`](https://github.com/mbasso/asm-dom/bl
 ```
 
 However there are some special identifiers that are automatically interpreted as props like `value` or `checked`. This is particularly convenient to avoid a code like `<input [value]={variable} />` every time.
-In addition, every attribute that starts with `on` is automatically interpreted as callbacks and rendered lowercase, for example:
+In addition, `ref` and every attribute that starts with `on` is automatically interpreted as callbacks and rendered lowercase, for example:
 
 ```
 <button onClick={callback} />
+<button ref={callback} />
 
 // is equal to
 
 <button (onclick)={callback}>
+<button (ref)={callback}>
 ```
 
-If you want to declare an attribute that stars with `on`, `value` or `checked`, so, you want to ignore these rules, you can surround it with curly brackets:
+If you want to declare an attribute that stars with `on`, `ref`, `value` or `checked`, so, you want to ignore these rules, you can surround it with curly brackets:
 
 ```
 <button onClick={callback} /> // this is an "onclick" callback
@@ -337,4 +340,36 @@ If you want to render a comment into the DOM, you can do something like:
   <!-- I'll be rendered! -->
   Hello World!
 </div>
+```
+
+## Fragments
+
+[DocumentFragments](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment) can be written using a special selector `Fragment`:
+
+```js
+<Fragment>
+	<div>Div content</div>
+  Hello World!
+</Fragment>
+```
+
+In this way you can group a list of children without adding extra nodes to the DOM.
+
+```js
+
+// this cannot be done
+/* asmdom::VNode* vnode = (
+	<div>Child 1</div>
+	<div>Child 2</div>
+	<div>Child 3</div>
+); */
+
+// this is a valid alternative to the code above
+asmdom::VNode* vnode = (
+	<Fragment>
+		<div>Child 1</div>
+		<div>Child 2</div>
+		<div>Child 3</div>
+	</Fragment>
+);
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gccx",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Transforms CPX (JSX like syntax) into asm-dom Virtual DOM",
   "main": "lib/index.js",
   "jsnext:main": "es/index.js",

--- a/src/language.jison
+++ b/src/language.jison
@@ -98,7 +98,7 @@ CPXClosingElement
 
 CPXElementName
     : CPXIdentifier
-        { $$ = 'u8"' + $1 + '"'; }
+        { $$ = 'u8"' + ($1 === 'Fragment' ? '' : $1) + '"'; }
     | CPXNamespacedName
         { $$ = 'u8"' + $1 + '"'; }
     | CPXMemberExpression
@@ -183,7 +183,7 @@ CPXAttributeIdentifier
         %{
             var name = $1;
             var type = 'attr';
-            if (name.indexOf('on') === 0) {
+            if (name.indexOf('on') === 0 || name === 'ref') {
                 name = name.toLowerCase();
                 type = 'callback';
             } else if (name === 'value' || name === 'checked') {

--- a/test/tests.js
+++ b/test/tests.js
@@ -64,6 +64,23 @@ export default [
     output: 'asmdom::h(u8"!", std::string(u8"  "))',
   },
   {
+    message: 'should parse fragments',
+    input: '<Fragment>   </Fragment>',
+    output: 'asmdom::h(u8"")',
+  },
+  {
+    message: 'should parse fragments with children',
+    input: `
+      < Fragment > 
+        { /* comment here */ }
+        { function(foo, bar) }
+        Hello world!
+        <input /> 
+      < / Fragment >
+    `,
+    output: 'asmdom::h(u8"", asmdom::Children {function(foo, bar), asmdom::h(u8"Hello world!", true), asmdom::h(u8"input")})',
+  },
+  {
     message: 'should support all syntax in comments',
     input:
       '<!-- VNodeChildrenstringreturn-><>/*.-:!={} []()\\"\'0123456789 identifier0123456789 -->',
@@ -348,6 +365,11 @@ export default [
     message: 'should recognize callbacks without round brackets',
     input: '<span onClick={onClick} />',
     output: 'asmdom::h(u8"span", asmdom::Data (asmdom::Callbacks {{u8"onclick", onClick}}))',
+  },
+  {
+    message: 'should recognize ref without round brackets',
+    input: '<span ref={refCallback} />',
+    output: 'asmdom::h(u8"span", asmdom::Data (asmdom::Callbacks {{u8"ref", refCallback}}))',
   },
   {
     message: 'should parse attributes with spaces',
@@ -646,6 +668,19 @@ export default [
           VNode* vnode = <span />;
         }
       `,
+      `
+        template<class T1> struct bar
+        {
+          void doStuff() { std::cout << ""; }
+        };
+
+        template<>
+        struct bar<int>
+        {
+        void doStuff() { std::cout << ""; }
+        };
+      `,
+      'friend bool operator==<>(ValueIter<Type> const &rhs, ValueIter<Type> const &lhs);',
     ],
     output: [
       `#include <iostream>
@@ -719,6 +754,17 @@ export default [
           }
           VNode* vnode = asmdom::h(u8"span");
         }`,
+      `template<class T1> struct bar
+        {
+          void doStuff() { std::cout << ""; }
+        };
+
+        template<>
+        struct bar<int>
+        {
+        void doStuff() { std::cout << ""; }
+        };`,
+        'friend bool operator==<>(ValueIter<Type> const &rhs, ValueIter<Type> const &lhs);',
     ],
   },
 ];


### PR DESCRIPTION
Add support for `ref` and `fragments` features of asm-dom@0.6.0

```js
// ref is automatically interpreted as callback
// use just
<button ref={callback} />
// instead of
<button (ref)={callback}>


// fragments can be defined with a special selector "Fragment"
<Fragment>
  <div>Child 1</div>
  <div>Child 2</div>
  <div>Child 3</div>
</Fragment>
```